### PR TITLE
Add support for client tls

### DIFF
--- a/cifsdk/cli.py
+++ b/cifsdk/cli.py
@@ -5,6 +5,7 @@ import sys
 import textwrap
 from argparse import ArgumentParser
 from argparse import RawDescriptionHelpFormatter
+from argparse import FileType
 
 from csirtg_indicator.format import FORMATS
 from cifsdk.utils import setup_logging, get_argument_parser
@@ -119,6 +120,8 @@ def main():  # pragma: no cover
     p.add_argument('--remote', help='specify API remote [default %(default)s]',
                    default=REMOTE)
     p.add_argument('--no-verify-ssl', action='store_true')
+    p.add_argument('--cert', type=FileType('r'), help="client tls certificate file")
+    p.add_argument('--key', type=FileType('r'), help="client tls key file")
 
     p.add_argument("--create", action="store_true", help="create an indicator")
     p.add_argument('--delete', action='store_true')
@@ -180,7 +183,7 @@ def main():  # pragma: no cover
         if args.remote == 'https://localhost':
             verify_ssl = False
 
-        cli = Client(verify_ssl=verify_ssl)
+        cli = Client(verify_ssl=verify_ssl, key=args.key, cert=args.cert)
 
     else:
         from cifsdk.client.zeromq import ZMQ

--- a/cifsdk/client/http/base.py
+++ b/cifsdk/client/http/base.py
@@ -41,10 +41,13 @@ class Base(object):
         self.verify_ssl = kwargs.get('verify_ssl', True)
         self.nowait = kwargs.get('nowait', False)
         self.timeout = timeout
+        self.cert = kwargs.get('cert', None) and kwargs.get('cert', None).name
+        self.key = kwargs.get('key', None) and kwargs.get('key', None).name
 
         self.remote = kwargs.get('remote', REMOTE)
 
         self.session = requests.Session()
+        self.session.cert=((self.cert,self.key))
         self.session.headers["Accept"] = 'application/vnd.cif.v5+json'
         self.session.headers['User-Agent'] = 'cifsdk-py/{}'.format(VERSION)
         self.session.headers['Accept-Encoding'] = 'deflate'


### PR DESCRIPTION
* adds flags for client tls to cli
  - `--cert`
  - `--key`
* updates client.http.base.Client to pass tls creds to http client
  session

Since the v5 api drops native authentication via api keys, it seems like the client should support mTLS for those of us who have chosen to use it as an authentication mechanism in a reverse proxy.

Code change is pretty simple, I based it on current master, but will need a rebase if/when #8 is merged